### PR TITLE
quebrar-tarefa

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,5 +96,5 @@ workflows:
   testes-de-workflows:
     jobs:
       - predicao-de-sexo
-      # - deteccao-sars-cov-2
-      # - deteccao-linhagem-covid
+      - deteccao-sars-cov-2
+      - deteccao-linhagem-covid

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ commands:
               mkdir -p ~/workdir/$directory; 
               cp $i ~/workdir/$directory; 
             done
+          when: always
 
 
 jobs:
@@ -95,5 +96,5 @@ workflows:
   testes-de-workflows:
     jobs:
       - predicao-de-sexo
-      - deteccao-sars-cov-2
-      - deteccao-linhagem-covid
+      # - deteccao-sars-cov-2
+      # - deteccao-linhagem-covid

--- a/predicao-de-sexo/predicao-de-sexo.wdl
+++ b/predicao-de-sexo/predicao-de-sexo.wdl
@@ -56,7 +56,8 @@ task CountVariants {
     # como inputs da task usamos a notação "~{nome_do_input}". Documentação completa em
     # https://github.com/openwdl/wdl/blob/main/versions/1.1/SPEC.md#an-example-wdl-workflow
     command <<<
-        set -eux
+        set -e  # Importante para que o script pare no primeiro erro que ocorrer.
+
         # A sintaxe ~{sep=" " vcf_files} é de WDL, ela expande o array
         # em uma string separada por espaço. Ex: "item1 item2 item3".
         # De resto, isto é apenas um for-loop em bash.
@@ -102,7 +103,7 @@ task CalculateCoverages {
         echo -e "~{interval}" >> interval.bed
         for bam in ~{sep=" " bam_files}; do
             name=$(basename $bam .bam)
-            mosdepth --chrom chrY --no-per-base --thresholds 10,20,30,40 --by interval.bed $name.output $bam
+            mosdepth --chrom chrY --no-per-base --parametro-que-nao-existe --thresholds 10,20,30,40 --by interval.bed $name.output $bam
             data=$(zcat $name.output.thresholds.bed.gz | grep SRY)
             echo -e "$name\t$data" >> coverages.txt
         done

--- a/predicao-de-sexo/test_sex_prediction.yml
+++ b/predicao-de-sexo/test_sex_prediction.yml
@@ -1,19 +1,3 @@
-- name: Teste do workflow para predição de sexo.
-  command: miniwdl run -i tests/inputs.json predicao-de-sexo.wdl
-  files:
-    - path: "_LAST/out/predictions/stdout.txt"
-      contains:
-        - "CXT070-001.sry\tmale"
-        - "KAB133-001.sry\tmale"
-        - "NQB080-001.sry\tmale"
-        - "OZX502-001.sry\tfemale"
-        - "UQE098-001.sry\tfemale"
-        - "CXT070-001\tmale"
-        - "KAB133-001\tmale"
-        - "NQB080-001\tmale"
-        - "OZX502-001\tfemale"
-        - "UQE098-001\tfemale"
-
 - name: Teste da tarefa CountVariants. Conta het. e hom. no cromossomo X da amostra.
   command: miniwdl run --task CountVariants -i tests/count-variants.inputs.json predicao-de-sexo.wdl
   files:
@@ -35,3 +19,19 @@
         - "NQB080-001.sry\tchrY\t2786854\t2787741\tSRY\t747\t709\t678\t649"
         - "OZX502-001.sry\tchrY\t2786854\t2787741\tSRY\t0\t0\t0\t0"
         - "UQE098-001.sry\tchrY\t2786854\t2787741\tSRY\t0\t0\t0\t0"
+
+- name: Teste do workflow para predição de sexo.
+  command: miniwdl run -i tests/inputs.json predicao-de-sexo.wdl
+  files:
+    - path: "_LAST/out/predictions/stdout.txt"
+      contains:
+        - "CXT070-001.sry\tmale"
+        - "KAB133-001.sry\tmale"
+        - "NQB080-001.sry\tmale"
+        - "OZX502-001.sry\tfemale"
+        - "UQE098-001.sry\tfemale"
+        - "CXT070-001\tmale"
+        - "KAB133-001\tmale"
+        - "NQB080-001\tmale"
+        - "OZX502-001\tfemale"
+        - "UQE098-001\tfemale"


### PR DESCRIPTION
A tarefa que move os arquivos de log para o diretorio a ser salvo no CircleCI precisa ser executado sempre, independentemente do job anterior ter falhado.

Neste PR corrigimos isso e também adicionamos um erro "didático" na etapa em que calculamos a cobertura na região SRY do cromossomo Y.

**Este PR pode entrar mesmo sem os testes estarem passando.**