### PR TITLE
Remove parâmetro inexistente

### DIFF
--- a/predicao-de-sexo/predicao-de-sexo.wdl
+++ b/predicao-de-sexo/predicao-de-sexo.wdl
@@ -103,7 +103,7 @@ task CalculateCoverages {
         echo -e "~{interval}" >> interval.bed
         for bam in ~{sep=" " bam_files}; do
             name=$(basename $bam .bam)
-            mosdepth --chrom chrY --no-per-base --parametro-que-nao-existe --thresholds 10,20,30,40 --by interval.bed $name.output $bam
+            mosdepth --chrom chrY --no-per-base --thresholds 10,20,30,40 --by interval.bed $name.output $bam
             data=$(zcat $name.output.thresholds.bed.gz | grep SRY)
             echo -e "$name\t$data" >> coverages.txt
         done


### PR DESCRIPTION
Remove parâmetro inexistente no workflow de predição de teste no mosdepth.